### PR TITLE
10.0 fix cancel invoice import

### DIFF
--- a/l10n_es_aeat_sii_restapi/models/account_invoice_import.py
+++ b/l10n_es_aeat_sii_restapi/models/account_invoice_import.py
@@ -209,7 +209,6 @@ class AccountInvoiceImport(models.Model):
                     invoice.action_invoice_cancel()
                     invoice.action_invoice_draft()
                     invoice.internal_number = False
-                    invoice.move_name = False
                     invoice.invoice_line_ids.unlink()
             inv_import.state = "draft"
         return True

--- a/l10n_es_aeat_sii_restapi/models/account_invoice_import.py
+++ b/l10n_es_aeat_sii_restapi/models/account_invoice_import.py
@@ -203,11 +203,13 @@ class AccountInvoiceImport(models.Model):
                 if not invoice.sii_state or invoice.sii_state not in ["sent", "sent_w_errors", "sent_modified"]:
                     invoice.action_cancel()
                     invoice.internal_number = False
+                    invoice.move_name = False
                     invoice.unlink()
                 else:
                     invoice.action_invoice_cancel()
                     invoice.action_invoice_draft()
                     invoice.internal_number = False
+                    invoice.move_name = False
                     invoice.invoice_line_ids.unlink()
             inv_import.state = "draft"
         return True


### PR DESCRIPTION
Cuando cancelamos una importación de facturas, en el caso de que la factura relacionada (account.invoice) tenemos que borrarla, previamente, ademas de quitar el "internal_number", tenemos que quitar tambien el "move_name", si no, saltará raise