### PR TITLE
[FIX] account_invoice_report: Se corta al imprimir

### DIFF
--- a/account_invoice_report/views/report_invoice.xml
+++ b/account_invoice_report/views/report_invoice.xml
@@ -244,7 +244,7 @@
         <field name="format">A4</field>
         <field name="orientation">Portrait</field>
         <field name="margin_top">95</field>
-        <field name="margin_bottom">60</field>
+        <field name="margin_bottom">65</field>
         <field name="margin_left">7</field>
         <field name="margin_right">7</field>
         <field name="header_line" eval="False"/>


### PR DESCRIPTION
Al imprimir una factura, como el margen inferior era muy pequeño se cortaba el pie al imprimir.